### PR TITLE
Updating to guard ~>2.0, subclassing Guard::Plugin

### DIFF
--- a/guard-preek.gemspec
+++ b/guard-preek.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "preek", "~> 1.2"
-  spec.add_runtime_dependency 'guard', '>= 1.6', '>= 1.6'
+  spec.add_runtime_dependency 'guard', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/guard/preek.rb
+++ b/lib/guard/preek.rb
@@ -1,9 +1,9 @@
 require "guard/preek/version"
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class Preek < Guard
+  class Preek < Guard::Plugin
     autoload :Runner, 'guard/preek/runner'
 
     def run_on_changes(paths)

--- a/spec/guard/integration_spec.rb
+++ b/spec/guard/integration_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Guard::Preek do
   include CaptureHelper
 
-  Given(:guard){ Guard::Preek.new([], options) }
+  Given(:guard){ Guard::Preek.new(options) }
   Given(:options){ Hash.new }
 
   context '#run_on_changes' do

--- a/spec/guard/preek_spec.rb
+++ b/spec/guard/preek_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Guard::Preek do
 
-  Given(:guard){ Guard::Preek.new([], options) }
+  Given(:guard){ Guard::Preek.new(options) }
   Given(:options){ Hash.new }
   Given(:paths){ ['some_file.rb'] }
   Given(:runner){ double('runner', perform: true) }


### PR DESCRIPTION
Thanks for this useful tool!

If you're interested, this patch updates guard-peek to use the Guard 2.0, which has a new DSL. Plugins now subclass from Guard::Plugin instead of Guard::Guard. The initialize signature has changed also.

https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard

Tests pass. This patch eliminates the following 60 lines (!!) of deprecation warnings when starting guard:

```
******** BIG DEPRECATION WARNING !! ********

    Hi, Guard here.

    You're including lib/guard/guard.rb ...

    ... which contains code deprecated over a year ago!


    This file will likely be removed in the next version, so make sure you're
    not requiring it anywhere to ensure safe gem upgrades.

    If this message is annoying and you can't quickly fix the issue (see below),
    you have 2 options:

      1) Simply set the env variable "GUARD_GEM_SILENCE_DEPRECATIONS" to "1" to
      skip this message

      2) Freeze the gem to a previous version (not recommended because upgrades
      are cool and you might forget to unfreeze later!).

      E.g. in your Gemfile:

        if Time.now > Time.new(2014,11,10)
          gem 'guard', '~> 2.8'
        else
          # Freeze until 2014-11-10 - in case we forget to change back ;)
          gem 'guard', '= 2.7.3'
        end

    If you don't know which gem or plugin is requiring this file, here's a
    backtrace:

    /Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/gems/guard-2.8.2/lib/guard/guard.rb:45:in `<module:Guard>'
     >> /Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/gems/guard-2.8.2/lib/guard/guard.rb:3:in `<top (required)>'
     >> /Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/bundler/gems/guard-preek-0cf86a684fd9/lib/guard/preek.rb:3:in `require'
     >> /Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/bundler/gems/guard-preek-0cf86a684fd9/lib/guard/preek.rb:3:in `<top (required)>'
     >> /Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/gems/guard-2.8.2/lib/guard/plugin_util.rb:123:in `require'"

    Here's how to quickly upgrade/fix this (given you are a maintainer of the
    offending plugin or you want to prepare a pull request yourself):

      https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard

    Have fun!

    ******** END OF DEPRECATION MESSAGE ********

08:17:11 - WARN - Starting with Guard 2.0, Guard::Preek should inherit from Guard::Plugin
> [#] instead of Guard::Guard.
> [#] Please note that the constructor signature has changed from
> [#] Guard::Guard#initialize(watchers = [], options = {}) to
> [#] Guard::Plugin#initialize(options = {}).
> [#] For more information on how to upgrade for Guard 2.0, please head over
> [#] to: https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard
> [#]
> [#] Deprecation backtrace: /Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/gems/guard-2.8.2/lib/guard/ui.rb:107:in `deprecation'
> [#]    >/Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/gems/guard-2.8.2/lib/guard/guard.rb:94:in `initialize'
> [#]    >/Users/bashcoder/.rvm/gems/ruby-2.1.4@testapp/gems/guard-2.8.2/lib/guard/plugin_util.rb:75:in `new'

```
